### PR TITLE
Add simple UCI engine example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# new.ev
+# UCI Application
+
+This repository contains a simple Python implementation of a Universal Chess Interface (UCI) engine stub. The engine responds to basic UCI commands and always plays the fixed move `e2e4` when asked to search.
+
+## Running
+
+```bash
+python uci_app.py
+```
+
+Then send UCI commands via standard input.
+
+## Testing
+
+```bash
+pytest
+```

--- a/test_uci_app.py
+++ b/test_uci_app.py
@@ -1,0 +1,15 @@
+import subprocess
+
+def test_uci_flow():
+    proc = subprocess.Popen([
+        "python", "-u", "uci_app.py"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    out, _ = proc.communicate("uci\nisready\ngo\nquit\n", timeout=5)
+    lines = [line.strip() for line in out.splitlines() if line.strip()]
+    assert "uciok" in lines
+    assert "readyok" in lines
+    assert "bestmove e2e4" in lines

--- a/uci_app.py
+++ b/uci_app.py
@@ -1,0 +1,42 @@
+import sys
+
+
+class SimpleEngine:
+    def __init__(self):
+        self.moves = []
+
+    def handle_command(self, line: str):
+        line = line.strip()
+        if line == "uci":
+            print("id name SimplePythonUCI")
+            print("id author ChatGPT")
+            print("uciok")
+        elif line == "isready":
+            print("readyok")
+        elif line.startswith("position"):
+            parts = line.split("moves")
+            if len(parts) > 1:
+                moves_part = parts[1].strip()
+                self.moves = moves_part.split()
+            else:
+                self.moves = []
+        elif line.startswith("go"):
+            print("bestmove e2e4")
+        elif line == "quit":
+            return False
+        else:
+            # Ignore any other commands.
+            pass
+        sys.stdout.flush()
+        return True
+
+
+def main():
+    engine = SimpleEngine()
+    for line in sys.stdin:
+        if not engine.handle_command(line):
+            break
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement minimal Python UCI engine that responds to basic commands
- document usage and testing instructions
- add test to verify UCI flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a306b509c832482959b75a4cb551e